### PR TITLE
Freeze version for peewee.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 graphene>=2.0
-peewee
+peewee==2.10.2
 peewee_async
 singledispatch>=3.4.0.3
 iso8601


### PR DESCRIPTION
Latest version graphene-peewee-async is not working with latest peewee version.
Peewee>2.10.2 doesn't have class Clause.

```python
File "/usr/local/lib/python3.6/site-packages/graphene_peewee_async/queries.py", line 4, in <module>
    from peewee import (
ImportError: cannot import name 'Clause'
```
