### PR TITLE
Relation name is strange

### DIFF
--- a/graphene_peewee_async/converter.py
+++ b/graphene_peewee_async/converter.py
@@ -103,7 +103,11 @@ def convert_field_to_list_or_connection(field, registry=None):
             # Generate another queries for set until aggregate_rows implemented for peewee-async
             # https://github.com/05bit/peewee-async/issues/10
             connection_meta_class = type('Meta', (), {'node': _type})
-            connection_class = type('{}_{}_Connection'.format(field.field.rel_model.__name__, field.field.related_name),
+            connection_name = '{}_{}_Connection'.format(
+                field.field.rel_model.__name__,
+                ''.join([s.capitalize() for s in field.field.related_name.split('_')])
+            )
+            connection_class = type(connection_name,
                                     (PeeweeConnection,),
                                     {connection_meta_class.__name__: connection_meta_class})
             return PeeweeConnectionField(connection_class)


### PR DESCRIPTION
If we hawe model with 
``` python
field = ForeignKeyField(SomeModel, related_name='some_name')
```
then connection of this relation will be named like `SomeModel_some_name_Connection`
I think `SomeModel_SomeName_Connection` will sound better .