### PR TITLE
Pip 10 compatibility was added.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 import re
 import os
 from setuptools import find_packages, setup
-from pip.req import parse_requirements
+try:  # pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError:  # pip <= 9.0.3
+    from pip.req import parse_requirements
 
 
 install_reqs = parse_requirements('requirements.txt', session=False)


### PR DESCRIPTION
Installing with pip 10 raises an error `ImportError: No module named req`
